### PR TITLE
Fix license in package.json

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/google/schemarama"
   },
-  "license": "SEE LICENSE IN core/license",
+  "license": "Apache-2.0",
   "dependencies": {
     "axios": "^0.20.0",
     "child_process": "^1.0.2",


### PR DESCRIPTION
Current license value in the package configuration is not valid. When trying to use schemarama through npm the following error message appears when packing a bundle:
```
ERROR in WebpackLicensePlugin: License "SEE LICENSE IN core/license" for schemarama@0.0.3 is not a valid SPDX expression!

ERROR in WebpackLicensePlugin: could not find file specified in package.json license field of schemarama@0.0.3
```
I validated this fix by applying it locally and making sure that this error disappears.