### PR TITLE
Remove hard dependency on fs

### DIFF
--- a/core/third_party/shex/shex.js
+++ b/core/third_party/shex/shex.js
@@ -7661,12 +7661,6 @@ module.exports = function(module) {
 /* 13 */
 /***/ (function(module, exports) {
 
-module.exports = require("fs");
-
-/***/ }),
-/* 14 */
-/***/ (function(module, exports) {
-
 module.exports = require("path");
 
 /***/ })

--- a/core/util.js
+++ b/core/util.js
@@ -13,8 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-const fs = require('fs');
+try {
+    const fs = require('fs');
+    const fsAvailable = true;
+} catch (e) {
+    const fsAvailable = false;
+}
 const axios = require('axios');
 
 const jsonld = require('jsonld');
@@ -34,7 +38,10 @@ async function loadData(link) {
     if (link.match("^https?://")) {
         return (await axios.get(link)).data;
     }
-    return fs.readFileSync(link).toString();
+    if (fsAvailable) {
+        return fs.readFileSync(link).toString();
+    }
+    throw 'Filesystem is not available, cannot load local data';
 }
 
 /**


### PR DESCRIPTION
When trying to use schemarama from npm for code that will be running in browser the following errors appear:
```
ERROR in /home/elizusha/schemarama/core/util.js
Module not found: Error: Can't resolve 'fs' in '/home/elizusha/schemarama/core'
 @ /home/elizusha/schemarama/core/util.js 17:11-24
 @ /home/elizusha/schemarama/core/index.js
 @ ./src/index.js

ERROR in /home/elizusha/schemarama/core/third_party/shex/shex.js
Module not found: Error: Can't resolve 'fs' in '/home/elizusha/schemarama/core/third_party/shex'
 @ /home/elizusha/schemarama/core/third_party/shex/shex.js 7664:17-30
 @ /home/elizusha/schemarama/core/shexValidator.js
 @ /home/elizusha/schemarama/core/index.js
 @ ./src/index.js
```
I think that the problem is that fs module is only available for node.js. In browsers you cannot have access to the file system anyway. This PR removes hard dependency on fs module: if it's available it will be used, if it's not available it will not throw an error unless you try to load a local file.  
