### PR TITLE
Fix errors in shex module

### DIFF
--- a/core/third_party/shex/shex.js
+++ b/core/third_party/shex/shex.js
@@ -2991,7 +2991,7 @@ numericParsers[XSD + "double" ] = function (label, parseError) {
   return Number(label);
 };
 
-testRange = function (value, datatype, parseError) {
+function testRange (value, datatype, parseError) {
   const ranges = {
     //    integer            -1 0 1 +1 | "" -1.0 +1.0 1e0 NaN INF
     //    decimal            -1 0 1 +1 -1.0 +1.0 | "" 1e0 NaN INF
@@ -5677,7 +5677,7 @@ var ShExParser = (function () {
 
 // stolen as much as possible from SPARQL.js
 if (true) {
-  ShExJison = __webpack_require__(11).Parser; // node environment
+  const ShExJison = __webpack_require__(11).Parser; // node environment
 } else {}
 
 // Creates a ShEx parser with the given pre-defined prefixes


### PR DESCRIPTION
Right now when trying to use schemarama as npm module, the code fails in shex file on two lines with the following errors:

```
Uncaught ReferenceError: testRange is not defined
    at eval (shex.js:2989)
```

```
Uncaught ReferenceError: ShExJison is not defined
    at eval (shex.js:5675)
```

In the shex repo, these errors are fixed:

1. https://github.com/shexSpec/shex.js/blob/c5ed1ffbf3e87224050a179d8bcd0db718f9ec3a/packages/shex-parser/shex-parser.js#L3
2. https://github.com/shexSpec/shex.js/blob/c5ed1ffbf3e87224050a179d8bcd0db718f9ec3a/packages/shex-validator/shex-validator.js#L95

The proper solution is to regenerate shex bundle, but for now the quickest solution is to patch the code directly. This PR makes schemarama works for me.